### PR TITLE
[WIP] Load settings earlier because they are needed by the logger

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -6,6 +6,7 @@ export SCRIPT_ROOT
 source lib/include/string.sh
 source lib/include/colors.sh
 source lib/include/logger.sh
+source lib/include/settings.sh
 source lib/include/common.sh
 source lib/include/editor.sh
 source lib/include/tw_config.sh
@@ -14,7 +15,6 @@ source lib/include/port.sh
 source lib/include/dir.sh
 source lib/include/sid.sh
 source lib/include/deps.sh
-source lib/include/settings.sh
 source lib/include/git.sh
 source lib/include/logs.sh
 source lib/include/screen.sh


### PR DESCRIPTION
problem is that the logger depends on config vars for post logs dir
and config var loading depends on logger for error logging

add a ``set -u`` to witness the error